### PR TITLE
Update storybook tests for createNewPasswordForm and signInForm

### DIFF
--- a/src/components/forms/createNewPasswordForm/createNewPasswordForm.stories.tsx
+++ b/src/components/forms/createNewPasswordForm/createNewPasswordForm.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { fn } from '@storybook/test'
+
 import { CreateNewPasswordForm } from './'
 
 const meta = {
@@ -12,4 +14,8 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const CreateNewPasswordFormExample: Story = {}
+export const CreateNewPasswordFormExample: Story = {
+  args: {
+    onSubmit: fn(),
+  },
+}

--- a/src/components/forms/signInForm/signInForm.stories.ts
+++ b/src/components/forms/signInForm/signInForm.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { fn } from '@storybook/test'
 import { withRouter } from 'storybook-addon-remix-react-router'
 
 import { SignInForm } from './'
@@ -15,4 +16,8 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const SignInFormDefault: Story = {}
+export const SignInFormDefault: Story = {
+  args: {
+    onSubmit: fn(),
+  },
+}


### PR DESCRIPTION
Imported the 'fn' function from '@storybook/test' to handle form submit events in both 'createNewPasswordForm' and 'signInForm' Storybook tests. The 'args' object for these tests now includes an 'onSubmit' function to simulate this event.